### PR TITLE
Mudança da recuperação do id do membro por params

### DIFF
--- a/src/controllers/FeedbackController.js
+++ b/src/controllers/FeedbackController.js
@@ -73,7 +73,7 @@ module.exports = {
   },
 
   async getMemberDuties(req, res) {
-    const { memberId } = req.body;
+    const { memberId } = req.params;
     if (!memberId || memberId === null || memberId === undefined)
       return res.status(400).json({ msg: 'MEMBER ID IS INVALID' });
     try {

--- a/src/routes.js
+++ b/src/routes.js
@@ -62,7 +62,7 @@ routes.put(
   FeedbackController.updateMonitoring
 );
 routes.get("/duties/feedback/getId", authJe, FeedbackController.getId);
-routes.get('/member/feedback', FeedbackController.getMemberDuties);
+routes.get('/member/:memberId/feedback', FeedbackController.getMemberDuties);
 
 routes.get("/jes/:jeId/boards", BoardController.index)
 routes.post("/jes/:jeId/boards/register", BoardController.store)


### PR DESCRIPTION
Na rota `/member/feedback` estava indo por `body` a informação, porém em uma requisição `GET` não se deve ir um `body` e sim um `params`.

Nessa corração, houve a mudança: 

- rota `/member/feedback` para `/member/:memberId/feedback`