### PR TITLE
Fix: Pedindo o jeId pelo params

### DIFF
--- a/src/controllers/FeedbackController.js
+++ b/src/controllers/FeedbackController.js
@@ -4,7 +4,7 @@ const Member = require("../models/Member");
 
 module.exports = {
   async index(req, res) {
-    const { jeId } = req.body;
+    const { jeId } = req.params;
 
     if (!jeId || jeId === null || jeId === undefined)
       return res.status(400).json({ msg: 'JE ID IS INVALID' });

--- a/src/routes.js
+++ b/src/routes.js
@@ -52,7 +52,7 @@ routes.get("/duties/:jeId/today", DutyController.consult);
 routes.post("/duties/register", DutyController.store);
 routes.put("/duties/:dutyId/finish", authMember, DutyController.update);
 
-routes.get("/feedback", authJe, FeedbackController.index);
+routes.get("/feedback/:jeId", authJe, FeedbackController.index);
 routes.post("/duties/:dutyId/feedback", FeedbackController.store);
 routes.delete("/duties/feedback/delete", authJe, FeedbackController.delete);
 routes.put("/duties/feedback/update", authMember, FeedbackController.update);


### PR DESCRIPTION
Agora a rota `/feedback `em vez de passar por `body` o `jeId`, na verdade, passa-se por params na rota `/feedback/:jeId`