### PR TITLE
adicionando await e resolvendo erro do update da senha

### DIFF
--- a/src/controllers/BoardController.js
+++ b/src/controllers/BoardController.js
@@ -78,7 +78,7 @@ module.exports = {
 
       const board = await Board.findByPk(boardId)
       if (board) {
-        board.update({ name })
+        await board.update({ name })
         return res.status(200).json({ board })
       }
       return res.status(404).json({ msg: 'BOARD NOT FOUND' });

--- a/src/controllers/DutyController.js
+++ b/src/controllers/DutyController.js
@@ -164,12 +164,12 @@ module.exports = {
         const start = moment(duty.createdAt);
         const elapsedTime = moment.range(start, end).diff('seconds');
 
-        duty.update({
+        await duty.update({
           status: 1,
           elapsedTime
         })
 
-        member.update({
+        await member.update({
           isDutyDone: 1
         })
 
@@ -198,12 +198,12 @@ module.exports = {
         const start = moment(duty.createdAt);
         const elapsedTime = moment.range(start, end).diff('seconds');
 
-        duty.update({
+        await duty.update({
           status: 1,
           elapsedTime
         })
 
-        member.update({
+        await member.update({
           isDutyDone: 1
         })
 

--- a/src/controllers/FeedbackController.js
+++ b/src/controllers/FeedbackController.js
@@ -169,7 +169,7 @@ module.exports = {
       if (!feedback)
         return res.status(404).json({ msg: "FEEDBACK NOT FOUND" });
 
-      feedback.update({
+      await feedback.update({
         isMonitoringDone: 1,
       });
 
@@ -211,7 +211,7 @@ module.exports = {
       if (!feedback)
         return res.status(404).json({ msg: "FEEDBACK NOT FOUND" });
 
-      feedback.update({
+      await feedback.update({
         satisfaction: satisfaction,
         productivity: productivity,
         mood: mood,

--- a/src/controllers/JeController.js
+++ b/src/controllers/JeController.js
@@ -101,7 +101,6 @@ module.exports = {
 
     const { password, name, university, city, creationYear } = req.body;
     if (!name || name == null || name == undefined) errors.push({ msg: 'NAME IS INVALID' })
-    if (!password || password == null || password == undefined) errors.push({ msg: 'PASSWORD IS INVALID' })
     if (!university || university == null || university == undefined) errors.push({ msg: 'UNIVERSITY IS INVALID' })
     if (!city || city == null || city == undefined) errors.push({ msg: 'CITY IS INVALID' })
     if (!creationYear || creationYear == null || creationYear == undefined) errors.push({ msg: 'CREATION YEAR IS INVALID' })
@@ -109,8 +108,10 @@ module.exports = {
 
     if (req.level !== 'je')
       return res.status(401).json({ msg: 'NOT A JE TOKEN' });
-    
-    const hash = generateHash(password);
+
+    let hash;
+    if (password)
+      hash = generateHash(password);
 
     try {
       const je = await Je.findByPk(req.id);
@@ -119,7 +120,7 @@ module.exports = {
           const { key } = req.file;
           if (je.image)
             promisify(fs.unlink)(path.resolve(__dirname, '..', '..', 'public', 'uploads', 'je', je.image));
-          je.update({
+          await je.update({
             name: name,
             password: hash,
             university: university,
@@ -129,7 +130,7 @@ module.exports = {
           });
         }
         else {
-          je.update({
+          await je.update({
             name: name,
             password: hash,
             university: university,

--- a/src/controllers/MemberController.js
+++ b/src/controllers/MemberController.js
@@ -149,7 +149,6 @@ module.exports = {
     const errors = []
 
     const { id, name, boardId, password, position, sr, isDutyDone } = req.body;
-    if (!password || password == null || password == undefined) errors.push({ msg: 'PASSWORD IS INVALID' })
     if (!name || name == null || name == undefined) errors.push({ msg: 'NAME IS INVALID' })
     if (!boardId || boardId == null || boardId == undefined) errors.push({ msg: 'BOARD ID IS INVALID' })
     if (!position || position == null || position == undefined) errors.push({ msg: 'POSITION IS INVALID' })
@@ -159,6 +158,10 @@ module.exports = {
     if (req.level !== 'je')
       return res.status(401).json({ msg: 'NOT A JE TOKEN' });
 
+    let hash;
+    if (password)
+      hash = generateHash(password);
+
     try {
       const member = await Member.findByPk(id);
       if (member) {
@@ -166,9 +169,10 @@ module.exports = {
           const { key } = req.file;
           if (member.image)
             promisify(fs.unlink)(path.resolve(__dirname, '..', '..', 'public', 'uploads', 'member', member.image));
-          member.update({
+          await member.update({
             name: name,
             boardId: boardId,
+            boardId: hash,
             position: position,
             sr: sr,
             image: key,
@@ -176,9 +180,10 @@ module.exports = {
           });
         }
         else
-          member.update({
+          await member.update({
             name: name,
             boardId: boardId,
+            boardId: hash,
             position: position,
             sr: sr,
             isDutyDone: parseInt(isDutyDone),


### PR DESCRIPTION
Estava ocorrendo o erro de no update de ej e membro não estarem atualizando a senha.
Foi adicionado await nos métodos update do sequelize e retirada a verificação da senha ser nula para poder receber valor nulo significando que a senha não será alterada.