### PR TITLE
Ordenar plantões

### DIFF
--- a/src/controllers/FeedbackController.js
+++ b/src/controllers/FeedbackController.js
@@ -95,6 +95,7 @@ module.exports = {
       const member = await Member.findByPk(memberId, {
         include: [{
           association: 'duties',
+          order: [['id', 'DESC']],
           include: [{ association: 'feedback' }]
         }]
       });

--- a/src/controllers/FeedbackController.js
+++ b/src/controllers/FeedbackController.js
@@ -95,7 +95,6 @@ module.exports = {
       const member = await Member.findByPk(memberId, {
         include: [{
           association: 'duties',
-          order: [['id', 'DESC']],
           include: [{ association: 'feedback' }]
         }]
       });
@@ -104,6 +103,14 @@ module.exports = {
         return res.status(404).json({ msg: 'MEMBER NOT FOUND' });
 
       member.password = undefined;
+      member.duties.sort((dutyA, dutyB) => {
+        if (dutyA.createdAt > dutyB.createdAt)
+          return -1;
+        else if (dutyA.createdAt < dutyB.createdAt)
+          return 1;
+        else
+          return 0;
+      });
       return res.status(200).json(member);
     } catch (error) {
       console.log(error);


### PR DESCRIPTION
Ordenando os plantões para os mais recentes primeiro. Utilizando .sort pois aparentemente não tem como ordenar o que vem do inner join.

Issue do sequelize que tentei testar: [https://github.com/sequelize/sequelize/issues/4553](url)